### PR TITLE
Set runtime context

### DIFF
--- a/jsontoxml.py
+++ b/jsontoxml.py
@@ -1,3 +1,4 @@
+import os, sys
 import json
 from datetime import datetime
 import xml.etree.ElementTree as ET
@@ -279,6 +280,7 @@ def getReadableDate(ts):
 
 
 def main():
+    os.chdir(sys.path[0])
 
     with open('Hangouts.json', encoding="utf8") as f:
         datastore = f.read()


### PR DESCRIPTION
When executing the script directly, a runtime context may not be set on some systems. Utilize the system path's first parameter -- where the script exists -- and set the runtime container. This allows simple access to files and folders alongside the script, in this case Hangouts JSON and assets.

Refs #10.