### PR TITLE
Bring participant info extraction into its own function and support phone number entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@ I made this for myself and thought I would share it with whomever wandered acros
 1. Go to takeout.google.com and have them prepare your Hangouts JSON (JSON is the default format option). Follow Google's instructions to retrieve.
 2. Make sure you have Python 3 installed (I'm running 3.7, but I'm probably not running anything very specific to it. Python 2 blows up on the encoding).
 3. Download jsontoxml.py
-4. Put jsontoxml.py and Hangouts.json in the same folder 
+4. Put jsontoxml.py and Hangouts.json in the same folder
 5. Open a command window (terminal should work as well, but I've only tested on Windows) and navigate to the folder from step 4
 6. Type "python3 jsontoxml.py" and hit enter.
 **Note**: _This script requires python 3 to run. If your OS installs python 3 in a different location such as "python" that may work as well. In many cases the nonspecific use of "python" still defaults to python2 which is why python3 is deliberately used here but steps to invoke python3 on your OS may differ._
+_Additionally, you may pass the `-p` argument to the script if you'd like for it to prompt for phone numbers when one can't be found during conversation mapping._
 7. If you get no errors, then you should be able to go to back to your folder and see test.xml
 8. Download SMS Backup & Restore https://play.google.com/store/apps/details?id=com.riteshsahu.SMSBackupRestore on the phone you're transferring the messages to.
 9. Get test.xml to your phone (my method was Google Drive)

--- a/jsontoxml.py
+++ b/jsontoxml.py
@@ -1,9 +1,9 @@
 import os, sys
+import argparse
 import json
 from datetime import datetime
 import xml.etree.ElementTree as ET
 import re
-
 import time
 
 
@@ -13,34 +13,16 @@ def current_milli_time(): return int(round(time.time() * 1000))
 def singlePath(root, thread):
     participant_data = thread['conversation']['conversation']['participant_data']
 
-    if 'phone_number' in participant_data[0].keys():
-        # number
-        phone = participant_data[0]['phone_number']['e164']
-        if 'i18n_data' in participant_data[0]['phone_number'].keys():
-            is_valid = participant_data[0]['phone_number']['i18n_data']['is_valid']
-            if not is_valid:
-                # likely a short code, skip
-                return 0
-            # name
-            name = participant_data[0]['fallback_name']
-        else:
-            return 0
-    # Unknown case where object 0 has no phone number and is the only object in array. Submitted by reddit user.
-    elif len(thread['conversation']['conversation']['participant_data']) < 2:
-        return 0
-    # if this fails and it's not a Group message, then it's a hangouts message (or incoming message?)
-    elif 'phone_number' in participant_data[1].keys():
-        phone = participant_data[1]['phone_number']['e164']
-        name = participant_data[1]['fallback_name']
-        if 'i18n_data' in participant_data[1]['phone_number'].keys():
-            is_valid = participant_data[1]['phone_number']['i18n_data']['is_valid']
-            if not is_valid:
-                # likely a short code, skip
-                return 0
-        else:
+    phone, name = getParticipantInfo(participant_data[0])
+    if None in (phone, name):
+        # Unknown case where object 0 has no phone number and is the only object in array. Submitted by reddit user.
+        if len(thread['conversation']['conversation']['participant_data']) < 2:
             return 0
 
-    else:
+        # if this fails and it's not a Group message, then it's a hangouts message (or incoming message?)
+        phone, name = getParticipantInfo(participant_data[1])
+
+    if None in (phone, name):
         return 0
 
     count = 0
@@ -100,8 +82,7 @@ def groupIDs(thread):
             userID = participant_data['id']['chat_id']
             if participant_data.get('phone_number'):
                 phone_found = True
-                phoneNumber = participant_data['phone_number']['e164']
-                userName = participant_data['fallback_name']
+                phoneNumber, userName = getParticipantInfo(participant_data)
                 user_ids[userID] = (userName, phoneNumber)
             else:
                 # if this is an mms thread, the owner's phone # will be in "fallback_name" for some reason
@@ -261,6 +242,31 @@ def getMessage(msg):
     return text
 
 
+def getParticipantInfo(participant_data):
+
+    name = participant_data['fallback_name']
+
+    if 'phone_number' in participant_data.keys():
+        phone = participant_data['phone_number']['e164']
+
+        if 'i18n_data' in participant_data['phone_number'].keys():
+            is_valid = participant_data['phone_number']['i18n_data']['is_valid']
+            if not is_valid:
+                # likely a short code, skip
+                return None, None
+        else:
+            return None, None
+    elif 'gaia_id' in participant_data['id'].keys() and args.prompt:
+        id = participant_data['id']['gaia_id']
+        phone = input(f"Please provide the phone number (in E.164 format) for {name} (Google user ID {id}): ")
+        if not phone:
+            return None, None
+    else:
+        return None, None
+
+    return phone, name
+
+
 def getTimestamp(msg):
 
     # print(data['conversations'][28]['events'][0]['timestamp'])
@@ -302,5 +308,11 @@ def main():
     tree = ET.ElementTree(root)
     tree.write("test.xml")
 
+
+parser = argparse.ArgumentParser()
+parser.add_argument("-p", "--prompt",
+    help="Prompt for phone number input (for conversations) when not found",
+    action="store_true")
+args = parser.parse_args()
 
 main()


### PR DESCRIPTION
A phone number isn't always available when trying to port over conversations such as Hangouts-only. Prompts for a phone number one isn't present and when a Google user ID is. Modularizes things a bit so this process can be used in all the code paths previously using the phone number from participant data.

Resolves #10.